### PR TITLE
Allow events to be starred and create reminder notification

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -101,6 +101,7 @@ dependencies {
     releaseImplementation 'io.palaima.debugdrawer:debugdrawer-no-op:0.8.0'
 
     // Other libraries used
+    implementation 'com.evernote:android-job:1.2.4'
     implementation 'com.airbnb.android:lottie:2.5.0-beta3'
     implementation 'com.mikepenz:iconics-core:3.0.2@aar'
     implementation 'com.mikepenz:google-material-typeface:3.0.1.2.original@aar'

--- a/app/src/main/java/org/hackillinois/android/App.java
+++ b/app/src/main/java/org/hackillinois/android/App.java
@@ -2,6 +2,7 @@ package org.hackillinois.android;
 
 import android.support.multidex.MultiDexApplication;
 
+import com.evernote.android.job.JobManager;
 import com.fatboyindustrial.gsonjodatime.Converters;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
@@ -14,6 +15,7 @@ import net.danlew.android.joda.JodaTimeAndroid;
 import org.hackillinois.android.api.HackIllinoisAPI;
 import org.hackillinois.android.helper.Settings;
 import org.hackillinois.android.helper.Utils;
+import org.hackillinois.android.service.HackillinoisJobCreator;
 
 import io.palaima.debugdrawer.timber.data.LumberYard;
 import okhttp3.Cache;
@@ -50,6 +52,7 @@ public class App extends MultiDexApplication {
 	@Override
 	public void onCreate() {
 		super.onCreate();
+		JobManager.create(this).addJobCreator(new HackillinoisJobCreator());
 
 		CalligraphyConfig.initDefault(new CalligraphyConfig.Builder()
 				.setFontAttrId(R.attr.fontPath)

--- a/app/src/main/java/org/hackillinois/android/api/response/event/EventResponse.java
+++ b/app/src/main/java/org/hackillinois/android/api/response/event/EventResponse.java
@@ -22,7 +22,7 @@ public class EventResponse {
 	public static class Event {
 		@SerializedName("description") private String description;
 		@SerializedName("endTime") private DateTime endTime;
-		@SerializedName("id") private Long id;
+		@SerializedName("id") private long id;
 		@SerializedName("locations") private List<Location> locations;
 		@SerializedName("name") private String name;
 		@SerializedName("startTime") private DateTime startTime;
@@ -36,7 +36,7 @@ public class EventResponse {
 			return endTime;
 		}
 
-		public Long getId() {
+		public long getId() {
 			return id;
 		}
 
@@ -54,6 +54,21 @@ public class EventResponse {
 
 		public String getTag() {
 			return tag;
+		}
+
+		@Override
+		public boolean equals(Object o) {
+			if (this == o) return true;
+			if (o == null || getClass() != o.getClass()) return false;
+
+			Event event = (Event) o;
+
+			return getId() == event.getId();
+		}
+
+		@Override
+		public int hashCode() {
+			return (int) (getId() ^ (getId() >>> 32));
 		}
 	}
 

--- a/app/src/main/java/org/hackillinois/android/helper/Settings.java
+++ b/app/src/main/java/org/hackillinois/android/helper/Settings.java
@@ -7,6 +7,9 @@ import com.annimon.stream.Optional;
 
 import org.joda.time.DateTime;
 
+import java.util.HashSet;
+import java.util.Set;
+
 
 public class Settings {
 	public static final DateTime EVENT_START_TIME = new DateTime("2018-02-23T16:00:00-0600"); //  = 2018-02-23T22:00:00+0000
@@ -16,7 +19,8 @@ public class Settings {
 	private static final String PREFS_NAME = "AppPrefs";
 	private static final String AUTH_PREF = "AUTH";
 	private static final String LAST_TIME_AUTH_PREF = "LAST_TIME_AUTH";
-	private static final String HACKER_PREF = "HACKER";
+	private static final String HACKER_PREF = "IS_HACKER";
+	private static final String EVENT_STARRED_PREF = "IS_STARRED";
 	private static Settings INSTANCE;
 
 	private final SharedPreferences prefs;
@@ -33,6 +37,27 @@ public class Settings {
 
 	public static Settings get() {
 		return INSTANCE;
+	}
+
+	public boolean getIsEventStarred(long eventId) {
+		Set<String> starredEvents = prefs.getStringSet(EVENT_STARRED_PREF, new HashSet<>());
+		return starredEvents.contains(String.valueOf(eventId));
+	}
+
+	public void saveEventIsStarred(long eventId) {
+		Set<String> starredEvents = prefs.getStringSet(EVENT_STARRED_PREF, new HashSet<>());
+		starredEvents.add(String.valueOf(eventId));
+		SharedPreferences.Editor prefsEditor = prefs.edit();
+		prefsEditor.putStringSet(EVENT_STARRED_PREF, starredEvents);
+		prefsEditor.apply();
+	}
+
+	public void saveEventIsNotStarred(long eventId) {
+		Set<String> starredEvents = prefs.getStringSet(EVENT_STARRED_PREF, new HashSet<>());
+		starredEvents.remove(String.valueOf(eventId));
+		SharedPreferences.Editor prefsEditor = prefs.edit();
+		prefsEditor.putStringSet(EVENT_STARRED_PREF, starredEvents);
+		prefsEditor.apply();
 	}
 
 	public void saveAuthKey(String auth) {

--- a/app/src/main/java/org/hackillinois/android/helper/Settings.java
+++ b/app/src/main/java/org/hackillinois/android/helper/Settings.java
@@ -7,6 +7,7 @@ import com.annimon.stream.Optional;
 
 import org.joda.time.DateTime;
 
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -45,18 +46,24 @@ public class Settings {
 	}
 
 	public void saveEventIsStarred(long eventId) {
-		Set<String> starredEvents = prefs.getStringSet(EVENT_STARRED_PREF, new HashSet<>());
-		starredEvents.add(String.valueOf(eventId));
+		Set<String> starredEvents = Collections.unmodifiableSet(prefs.getStringSet(EVENT_STARRED_PREF, new HashSet<>()));
+		// note starredEvents should *NOT* be modified
+
 		SharedPreferences.Editor prefsEditor = prefs.edit();
-		prefsEditor.putStringSet(EVENT_STARRED_PREF, starredEvents);
+		Set<String> newStarredEvents = new HashSet<>(starredEvents);
+		newStarredEvents.add(String.valueOf(eventId));
+		prefsEditor.putStringSet(EVENT_STARRED_PREF, newStarredEvents);
 		prefsEditor.apply();
 	}
 
 	public void saveEventIsNotStarred(long eventId) {
-		Set<String> starredEvents = prefs.getStringSet(EVENT_STARRED_PREF, new HashSet<>());
-		starredEvents.remove(String.valueOf(eventId));
+		Set<String> starredEvents = Collections.unmodifiableSet(prefs.getStringSet(EVENT_STARRED_PREF, new HashSet<>()));
+		// note starredEvents should *NOT* be modified
+
 		SharedPreferences.Editor prefsEditor = prefs.edit();
-		prefsEditor.putStringSet(EVENT_STARRED_PREF, starredEvents);
+		Set<String> newStarredEvents = new HashSet<>(starredEvents);
+		newStarredEvents.remove(String.valueOf(eventId));
+		prefsEditor.putStringSet(EVENT_STARRED_PREF, newStarredEvents);
 		prefsEditor.apply();
 	}
 

--- a/app/src/main/java/org/hackillinois/android/helper/Utils.java
+++ b/app/src/main/java/org/hackillinois/android/helper/Utils.java
@@ -17,6 +17,8 @@ import net.glxn.qrgen.android.QRCode;
 
 import org.hackillinois.android.R;
 import org.hackillinois.android.api.response.event.EventResponse;
+import org.hackillinois.android.service.EventNotifierJob;
+import org.joda.time.Minutes;
 
 import java.util.Arrays;
 import java.util.Locale;
@@ -56,7 +58,14 @@ public class Utils {
 	}
 
 	public static void toggleEventStarred(ImageView star, EventResponse.Event event) {
-		setEventStarred(star, event, !Settings.get().getIsEventStarred(event.getId()));
+		boolean starred = !Settings.get().getIsEventStarred(event.getId());
+		setEventStarred(star, event, starred);
+
+		if (starred) {
+			EventNotifierJob.scheduleReminder(event, Minutes.minutes(15));
+		} else {
+			EventNotifierJob.cancelReminder(event);
+		}
 	}
 
 	public static void updateEventStarred(ImageView star, EventResponse.Event event) {
@@ -67,13 +76,9 @@ public class Utils {
 		GoogleMaterial.Icon icon;
 		if (starred) {
 			icon = GoogleMaterial.Icon.gmd_star;
-		} else {
-			icon = GoogleMaterial.Icon.gmd_star_border;
-		}
-
-		if (starred) {
 			Settings.get().saveEventIsStarred(event.getId());
 		} else {
+			icon = GoogleMaterial.Icon.gmd_star_border;
 			Settings.get().saveEventIsNotStarred(event.getId());
 		}
 

--- a/app/src/main/java/org/hackillinois/android/helper/Utils.java
+++ b/app/src/main/java/org/hackillinois/android/helper/Utils.java
@@ -8,13 +8,20 @@ import android.net.NetworkInfo;
 import android.support.v4.content.ContextCompat;
 import android.view.Window;
 import android.view.WindowManager;
+import android.widget.ImageView;
+
+import com.mikepenz.google_material_typeface_library.GoogleMaterial;
+import com.mikepenz.iconics.IconicsDrawable;
 
 import net.glxn.qrgen.android.QRCode;
 
 import org.hackillinois.android.R;
+import org.hackillinois.android.api.response.event.EventResponse;
 
 import java.util.Arrays;
 import java.util.Locale;
+
+import timber.log.Timber;
 
 public class Utils {
 	public static boolean isNetworkAvailable(Context context) {
@@ -46,5 +53,37 @@ public class Utils {
 		T[] result = Arrays.copyOf(first, first.length + second.length);
 		System.arraycopy(second, 0, result, first.length, second.length);
 		return result;
+	}
+
+	public static void toggleEventStarred(ImageView star, EventResponse.Event event) {
+		setEventStarred(star, event, !Settings.get().getIsEventStarred(event.getId()));
+	}
+
+	public static void updateEventStarred(ImageView star, EventResponse.Event event) {
+		setEventStarred(star, event, Settings.get().getIsEventStarred(event.getId()));
+	}
+
+	public static void setEventStarred(ImageView star, EventResponse.Event event, boolean starred) {
+		GoogleMaterial.Icon icon;
+		if (starred) {
+			icon = GoogleMaterial.Icon.gmd_star;
+		} else {
+			icon = GoogleMaterial.Icon.gmd_star_border;
+		}
+
+		if (starred) {
+			Settings.get().saveEventIsStarred(event.getId());
+		} else {
+			Settings.get().saveEventIsNotStarred(event.getId());
+		}
+
+		Timber.i("Setting event %s id=%d to be starred=%b", event.getName(), event.getId(), starred);
+
+		star.setImageDrawable(
+				new IconicsDrawable(star.getContext())
+						.icon(icon)
+						.colorRes(R.color.bluePurple)
+						.actionBar()
+		);
 	}
 }

--- a/app/src/main/java/org/hackillinois/android/service/EventNotifierJob.java
+++ b/app/src/main/java/org/hackillinois/android/service/EventNotifierJob.java
@@ -1,0 +1,87 @@
+package org.hackillinois.android.service;
+
+import android.app.Notification;
+import android.app.NotificationManager;
+import android.content.Context;
+import android.provider.Settings;
+import android.support.annotation.NonNull;
+import android.support.v4.app.NotificationCompat;
+
+import com.evernote.android.job.Job;
+import com.evernote.android.job.JobManager;
+import com.evernote.android.job.JobRequest;
+import com.evernote.android.job.util.support.PersistableBundleCompat;
+
+import org.hackillinois.android.R;
+import org.hackillinois.android.api.response.event.EventResponse;
+import org.joda.time.DateTime;
+import org.joda.time.Duration;
+import org.joda.time.ReadablePeriod;
+import org.joda.time.format.DateTimeFormat;
+import org.joda.time.format.DateTimeFormatter;
+
+import timber.log.Timber;
+
+public class EventNotifierJob extends Job {
+	private static final DateTimeFormatter DTF = DateTimeFormat.forPattern("h:mm a");
+	public static final String TAG = "event_notifier";
+	public static final String EVENT_NAME = "event_name";
+	public static final String EVENT_ID = "event_id";
+	public static final String EVENT_START_TIME = "event_start_time";
+
+	@NonNull
+	@Override
+	protected Result onRunJob(@NonNull Params params) {
+		PersistableBundleCompat extras = params.getExtras();
+		String eventName = extras.getString(EVENT_NAME, "Unknown");
+		int eventId = (int) extras.getLong(EVENT_ID, 0);
+		DateTime startTime = DateTime.parse(extras.getString(EVENT_START_TIME, ""));
+
+		Timber.d("Sending notification for %s", eventName);
+		Notification notification = new NotificationCompat.Builder(getContext(), TAG)
+				.setSmallIcon(R.mipmap.ic_launcher)
+				.setContentTitle(eventName)
+				.setContentText(eventName + " starts at " + DTF.print(startTime))
+				.setTimeoutAfter(startTime.getMillis())
+				.setWhen(startTime.getMillis())
+				.setVibrate(new long[]{1000, 1000})
+				.setSound(Settings.System.DEFAULT_NOTIFICATION_URI)
+				.build();
+
+		NotificationManager notificationManager = (NotificationManager) getContext().getSystemService(Context.NOTIFICATION_SERVICE);
+		notificationManager.notify(eventId, notification);
+		return Result.SUCCESS;
+	}
+
+	public static void cancelReminder(EventResponse.Event event) {
+		JobManager.instance().cancelAllForTag(getTag(event));
+		Timber.d("Canceled reminder for '%s'", event.getName());
+	}
+
+	public static void scheduleReminder(EventResponse.Event event, ReadablePeriod timeBefore) {
+		if (event.getStartTime().minus(timeBefore).isBeforeNow()) {
+			Timber.w("Reminder for event '%s' not scheduled because it is over.", event.getName());
+			return;
+		}
+
+		PersistableBundleCompat extras = new PersistableBundleCompat();
+		extras.putString(EVENT_NAME, event.getName());
+		extras.putString(EVENT_START_TIME, event.getStartTime().toString());
+		extras.putLong(EVENT_ID, event.getId());
+
+		DateTime timeToNotify = event.getStartTime().minus(timeBefore);
+		long msUntilNotify = new Duration(DateTime.now(), timeToNotify).getMillis();
+		new JobRequest.Builder(getTag(event))
+				.setExtras(extras)
+				.setExact(msUntilNotify)
+				.build()
+				.schedule();
+
+		Timber.d("Scheduled reminder for '%s'", event.getName());
+	}
+
+	@NonNull
+	private static String getTag(EventResponse.Event event) {
+		return TAG + "_" + event.getId();
+	}
+}

--- a/app/src/main/java/org/hackillinois/android/service/HackillinoisJobCreator.java
+++ b/app/src/main/java/org/hackillinois/android/service/HackillinoisJobCreator.java
@@ -1,0 +1,20 @@
+package org.hackillinois.android.service;
+
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+
+import com.evernote.android.job.Job;
+import com.evernote.android.job.JobCreator;
+
+public class HackillinoisJobCreator implements JobCreator {
+
+	@Nullable
+	@Override
+	public Job create(@NonNull String tag) {
+		if (tag.contains(EventNotifierJob.TAG)) {
+			return new EventNotifierJob();
+		}
+
+		return null;
+	}
+}

--- a/app/src/main/java/org/hackillinois/android/ui/modules/event/EventInfoDialog.java
+++ b/app/src/main/java/org/hackillinois/android/ui/modules/event/EventInfoDialog.java
@@ -3,6 +3,8 @@ package org.hackillinois.android.ui.modules.event;
 import android.app.Dialog;
 import android.content.Context;
 import android.support.annotation.NonNull;
+import android.view.View;
+import android.widget.ImageView;
 import android.widget.TextView;
 
 import org.hackillinois.android.R;
@@ -18,6 +20,7 @@ import timber.log.Timber;
 
 public class EventInfoDialog extends Dialog {
 	private EventResponse.Event event;
+	@BindView(R.id.event_star) ImageView eventStar;
 	@BindView(R.id.event_name) TextView eventName;
 	@BindView(R.id.event_location) TextView eventLocation;
 	@BindView(R.id.event_distance) TextView eventDistance;
@@ -43,6 +46,8 @@ public class EventInfoDialog extends Dialog {
 		eventLocation.setText(location);
 		eventDistance.setText("Building is far");
 		eventDescription.setText(event.getDescription());
+
+		Utils.updateEventStarred(eventStar, event);
 	}
 
 	@OnClick(R.id.event_info_close)
@@ -51,7 +56,8 @@ public class EventInfoDialog extends Dialog {
 	}
 
 	@OnClick(R.id.event_star)
-	public void favoriteEvent() {
+	public void favoriteEvent(View v) {
+		Utils.toggleEventStarred((ImageView) v, event);
 		Timber.w("Event \"%s\" Should be starred", event.getName());
 	}
 }

--- a/app/src/main/java/org/hackillinois/android/ui/modules/event/EventItem.java
+++ b/app/src/main/java/org/hackillinois/android/ui/modules/event/EventItem.java
@@ -10,6 +10,7 @@ import com.mikepenz.fastadapter.items.AbstractItem;
 
 import org.hackillinois.android.R;
 import org.hackillinois.android.api.response.event.EventResponse;
+import org.hackillinois.android.helper.Utils;
 
 import java.util.List;
 
@@ -70,11 +71,13 @@ public class EventItem extends AbstractItem<EventItem, EventItem.EventViewHolder
 			String location = locations.size() > 0 ? String.valueOf(locations.get(0).getLocationId()) : "unknown";
 			eventLocation.setText("Location id:" + location);
 			if (item.isStarrable()) {
+				Utils.updateEventStarred(eventStar, item.getEvent());
 				eventStar.setVisibility(View.VISIBLE);
 			} else {
 				eventStar.setVisibility(View.INVISIBLE);
 			}
 		}
+
 
 		@Override
 		public void unbindView(EventItem item) {

--- a/app/src/main/java/org/hackillinois/android/ui/modules/login/GitHubLoginActivity.java
+++ b/app/src/main/java/org/hackillinois/android/ui/modules/login/GitHubLoginActivity.java
@@ -3,6 +3,8 @@ package org.hackillinois.android.ui.modules.login;
 import android.annotation.SuppressLint;
 import android.content.Intent;
 import android.os.Bundle;
+import android.webkit.CookieManager;
+import android.webkit.CookieSyncManager;
 import android.webkit.WebView;
 import android.webkit.WebViewClient;
 import android.widget.Toast;
@@ -32,6 +34,7 @@ public class GitHubLoginActivity extends BaseActivity {
 		ButterKnife.bind(this);
 
 		githubWebview.clearCache(true);
+		clearCookies();
 		githubWebview.getSettings().setJavaScriptEnabled(true); // required for github
 		githubWebview.setWebViewClient(new WebViewClient() {
 			@Override
@@ -46,6 +49,12 @@ public class GitHubLoginActivity extends BaseActivity {
 			}
 		});
 		githubWebview.loadUrl(HackIllinoisAPI.AUTH);
+	}
+
+	private void clearCookies() {
+		CookieSyncManager.createInstance(this);
+		CookieManager cookieManager = CookieManager.getInstance();
+		cookieManager.removeAllCookie();
 	}
 
 	private void authenticateUser(String code) {

--- a/app/src/main/java/org/hackillinois/android/ui/modules/profile/ProfileFragment.java
+++ b/app/src/main/java/org/hackillinois/android/ui/modules/profile/ProfileFragment.java
@@ -85,9 +85,6 @@ public class ProfileFragment extends BaseFragment {
 	}
 
 	private void logOut() {
-		CookieSyncManager.createInstance(getContext());
-		CookieManager cookieManager = CookieManager.getInstance();
-		cookieManager.removeAllCookie();
 		Timber.i("Logging out current user!");
 		Settings.get().clear();
 		Intent i = new Intent(getContext(), LoginChooserActivity.class);

--- a/app/src/main/java/org/hackillinois/android/ui/modules/profile/ProfileFragment.java
+++ b/app/src/main/java/org/hackillinois/android/ui/modules/profile/ProfileFragment.java
@@ -65,8 +65,6 @@ public class ProfileFragment extends BaseFragment {
 				new IconicsDrawable(getContext())
 						.icon(GoogleMaterial.Icon.gmd_exit_to_app)
 						.colorRes(R.color.darkPurple)
-						.sizeDp(24)
-						.paddingDp(16)
 						.actionBar()
 		);
 	}

--- a/app/src/main/java/org/hackillinois/android/ui/modules/schedule/ScheduleDayFragment.java
+++ b/app/src/main/java/org/hackillinois/android/ui/modules/schedule/ScheduleDayFragment.java
@@ -20,6 +20,7 @@ import com.mikepenz.fastadapter.listeners.ClickEventHook;
 
 import org.hackillinois.android.R;
 import org.hackillinois.android.api.response.event.EventResponse;
+import org.hackillinois.android.helper.Utils;
 import org.hackillinois.android.ui.base.BaseFragment;
 import org.hackillinois.android.ui.modules.event.EventInfoDialog;
 import org.hackillinois.android.ui.modules.event.EventItem;
@@ -67,7 +68,9 @@ public class ScheduleDayFragment extends BaseFragment {
 		activeEvents.setAdapter(fastAdapter);
 
 		fastAdapter.withOnClickListener((v, adapter, item, position) -> {
-			new EventInfoDialog(getContext(), item.getEvent()).show();
+			EventInfoDialog dialog = new EventInfoDialog(getContext(), item.getEvent());
+			dialog.setOnDismissListener(di -> Utils.updateEventStarred(ButterKnife.findById(v, R.id.event_star), item.getEvent()));
+			dialog.show();
 			return false;
 		});
 
@@ -82,9 +85,12 @@ public class ScheduleDayFragment extends BaseFragment {
 			}
 
 			@Override
-			public void onClick(View v, int position, FastAdapter<EventItem> fastAdapter, EventItem item) {
-				if(v.getId() == R.id.event_star) {
-					Timber.w("Event \"%s\" Should be starred", item.getEvent().getName());
+			public void onClick(View v, int position, FastAdapter<EventItem> fastAdapter, EventItem
+					item) {
+				if (v.getId() == R.id.event_star) {
+					Utils.toggleEventStarred((ImageView) v, item.getEvent());
+				} else {
+
 				}
 			}
 		});

--- a/app/src/main/java/org/hackillinois/android/ui/modules/schedule/ScheduleDayFragment.java
+++ b/app/src/main/java/org/hackillinois/android/ui/modules/schedule/ScheduleDayFragment.java
@@ -1,5 +1,8 @@
 package org.hackillinois.android.ui.modules.schedule;
 
+import android.app.AlarmManager;
+import android.app.PendingIntent;
+import android.content.Context;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
@@ -85,12 +88,9 @@ public class ScheduleDayFragment extends BaseFragment {
 			}
 
 			@Override
-			public void onClick(View v, int position, FastAdapter<EventItem> fastAdapter, EventItem
-					item) {
+			public void onClick(View v, int position, FastAdapter<EventItem> fastAdapter, EventItem item) {
 				if (v.getId() == R.id.event_star) {
 					Utils.toggleEventStarred((ImageView) v, item.getEvent());
-				} else {
-
 				}
 			}
 		});


### PR DESCRIPTION
This resolves #64 

- Starred events are saved in a `Set<String>` in `SharedPreferences`.

- Notification jobs are scheduled when the star is toggled