### PR TITLE
Keep reference to api so it doesn't break after resuming

### DIFF
--- a/app/src/main/java/org/hackillinois/android/ui/SplashActivity.java
+++ b/app/src/main/java/org/hackillinois/android/ui/SplashActivity.java
@@ -8,7 +8,6 @@ import android.view.WindowManager;
 
 import com.annimon.stream.Optional;
 
-import org.hackillinois.android.BuildConfig;
 import org.hackillinois.android.R;
 import org.hackillinois.android.api.response.location.LocationResponse;
 import org.hackillinois.android.api.response.login.LoginResponse;
@@ -129,16 +128,13 @@ public class SplashActivity extends BaseActivity {
 	private void moveOn() {
 		Timber.d("Moving to %s", activityClass.getSimpleName());
 		Intent i = new Intent(this, activityClass);
-		i.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
 		startActivity(i);
 		finish();
 	}
 
 	@OnClick(R.id.splash_anim)
 	public void skipSplash() {
-		if (BuildConfig.DEBUG) {
-			Timber.i("Skipping splash screen");
-			moveOn();
-		}
+		Timber.i("Skipping splash screen");
+		moveOn();
 	}
 }

--- a/app/src/main/java/org/hackillinois/android/ui/base/BaseFragment.java
+++ b/app/src/main/java/org/hackillinois/android/ui/base/BaseFragment.java
@@ -3,21 +3,20 @@ package org.hackillinois.android.ui.base;
 import android.os.Bundle;
 import android.support.annotation.Nullable;
 import android.support.v4.app.Fragment;
-import android.support.v4.view.LayoutInflaterCompat;
-import android.support.v7.app.AppCompatActivity;
-
-import com.mikepenz.iconics.context.IconicsLayoutInflater2;
 
 import org.hackillinois.android.App;
 import org.hackillinois.android.api.HackIllinoisAPI;
 
 public class BaseFragment extends Fragment {
+	private HackIllinoisAPI api;
+
 	@Override
 	public void onCreate(@Nullable Bundle savedInstanceState) {
 		super.onCreate(savedInstanceState);
+		api = ((App) getActivity().getApplication()).getApi();
 	}
 
 	public HackIllinoisAPI getApi() {
-		return ((App) getActivity().getApplication()).getApi();
+		return api;
 	}
 }

--- a/app/src/main/java/org/hackillinois/android/ui/modules/profile/ProfileFragment.java
+++ b/app/src/main/java/org/hackillinois/android/ui/modules/profile/ProfileFragment.java
@@ -111,8 +111,10 @@ public class ProfileFragment extends BaseFragment {
 		Uri userBadge = Uri.parse(result.getContents());
 		String textId = userBadge.getQueryParameter("id");
 		String identifier = userBadge.getQueryParameter("identifier");
+		Timber.d("Scanning in user %s as %s", textId, identifier);
 		if (textId == null) {
 			Toast.makeText(getContext(), "Failed to scan any id", Toast.LENGTH_SHORT).show();
+			return;
 		}
 
 		int id = Integer.valueOf(textId);


### PR DESCRIPTION
Resolves #124 

- touch to skip splash activity
- made qr scanner more not crash on unexpected formats